### PR TITLE
Fix/leek hangs

### DIFF
--- a/django_leek/helpers.py
+++ b/django_leek/helpers.py
@@ -17,12 +17,12 @@ def serielize(task):
 
 
 def save_task_to_db(new_task):
-    t = models.QueuedTasks()
     pickled_task = serielize(new_task)
     t = models.QueuedTasks(pickled_task=pickled_task)
     t.save()
     new_task.db_id = t.id
     return new_task
+
 
 def save_task_failed(task,exception):
     t = models.FailedTasks(task_id=task.db_id, exception=str(exception))

--- a/django_leek/worker.py
+++ b/django_leek/worker.py
@@ -68,7 +68,10 @@ class Worker(threading.Thread):
                 log.info('...successfully')
             except Exception as e:
                 log.exception("...task failed")
-                helpers.save_task_failed(task, e)
-                
+                try:
+                    helpers.save_task_failed(task, e)
+                except Exception:
+                    log.exception("...could not update task as failed")
+
         self.worker_queue = None
         log.info('Worker stopped, {} tasks handled.'.format(self.tasks_counter))


### PR DESCRIPTION
Previously, if a failed task could not be saved to the db, the worker thread bailed out causing there to be no active thread that processes new jobs.

In Django tests, it's not easy to simlulate db failures, etc, so no test for this bugfix.