### PR TITLE
Force new db connection to be created for forkes

### DIFF
--- a/django_leek/server.py
+++ b/django_leek/server.py
@@ -42,6 +42,8 @@ class TaskSocketServer(socketserver.BaseRequestHandler):
                 log.info('Got a task')
                 try:
                     task_id = int(data.decode())
+                    
+                    # Connection are closed by tasks, force it to reconnect
                     django.db.connections.close_all()
                     queued_task = load_task(task_id=task_id)
                     

--- a/django_leek/worker.py
+++ b/django_leek/worker.py
@@ -18,6 +18,10 @@ def target(queue):
                 break
                 
             log.info('running task...')
+
+            # Force this forked process to create its own db connection
+            django.db.connection.close()
+
             task()
             # workaround to solve problems with django + psycopg2
             # solution found here: https://stackoverflow.com/a/36580629/10385696


### PR DESCRIPTION
PR make sure every task have its own db connection before starting, this allows leek to run tasks in parallel.  