### PR TITLE
Fixed erroneous syntax in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ With `django-leek` you can get up and running quickly The more complex distribut
     $ pip install django-leek
 	````
 
-2. Add `django-leek` to `INSTALLED_APPS` in your `settings.py` file.
+2. Add `django_leek` to `INSTALLED_APPS` in your `settings.py` file.
 
 3. Create tables needed
 
@@ -39,7 +39,7 @@ With `django-leek` you can get up and running quickly The more complex distribut
 4. Make sure the django-leek server is running.
 
 	```bash
-	$ python manage.py runleek
+	$ python manage.py leek
 	```
 
 5. Go nuts


### PR DESCRIPTION
In the django settings INSTALLED_APPS, it should be 'django_leek' not
'django-leek' and the command to run the leek server is 'python
manage.py leek' not 'python manage.py runleek'.

This fixes #12