### PR TITLE
Fix/multiple tasks

### DIFF
--- a/django_leek/server.py
+++ b/django_leek/server.py
@@ -19,16 +19,12 @@ log = logging.getLogger(__name__)
 def target(queue):
     django.setup()
     log.info('Worker Starts')
-    done = False
-    while not done:
+    while True:
         task_id = queue.get()
-        if task_id is None:
-            done = True
-            break
-
         log.info('running task...')
 
-        # Force this forked process to create its own db connection
+        # workaround to solve problems with django + psycopg2
+        # solution found here: https://stackoverflow.com/a/36580629/10385696
         django.db.connection.close()
 
         task = load_task(task_id=task_id)
@@ -47,12 +43,6 @@ def target(queue):
             task.finished_at = timezone.now()
             task.pickled_exception = helpers.serialize(e)
             task.save()
-
-    # workaround to solve problems with django + psycopg2
-    # solution found here: https://stackoverflow.com/a/36580629/10385696
-    django.db.connection.close()
-
-    log.info('Worker stopped')
 
 
 class Pool(object):

--- a/django_leek/server.py
+++ b/django_leek/server.py
@@ -111,7 +111,3 @@ class TaskSocketServer(socketserver.BaseRequestHandler):
         except OSError as e:
             # in case of network error, just log
             log.exception("network error")
-
-    def finish(self):
-        for pool in self.pools.values():
-            pool.queue.put(None)

--- a/django_leek/tests.py
+++ b/django_leek/tests.py
@@ -39,6 +39,7 @@ class TestServer(TestCase):
 
     def act(self):
         TaskSocketServer(self.request, 'client adress', 'server')
+        TaskSocketServer.stop()
 
     def test_recv_error(self):
         self._request(OSError('Nuclear Winter'))        


### PR DESCRIPTION
* Fixing an issue where tasks could be _dropped_ if queued while another task was running.
* To circumvent a race condition, workers now continue to run indefinitely.
