### PR TITLE
fix build lint error

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,3 +1,5 @@
- [MASTER]
- errors-only=yes
- load-plugins=pylint_django
+[MASTER]
+errors-only=yes
+load-plugins=pylint_django
+django-settings-module=test_app.settings
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "3.5"
   - "3.6"
 cache: pip
 script:


### PR DESCRIPTION
fixing linting error:

`django_leek/__init__.py:1:0: E5110: Django was not configured. For more information run pylint --load-plugins=pylint_django --help-msg=django-not-configured (django-not-configured)`