### PR TITLE
Catch exceptions from exception serialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ __pycache__/
 
 # test app
 db.sqlite3
+
+.idea/

--- a/django_leek/helpers.py
+++ b/django_leek/helpers.py
@@ -1,23 +1,30 @@
-import pickle
 import base64
+import pickle
 
 from . import models
 
 
-def unpack(pickled_task):
+def unpack(pickled_task: bytes):
     new_task = pickle.loads(base64.b64decode(pickled_task))
     return new_task
 
 
-def serialize(task):
-    return base64.b64encode(pickle.dumps(task))
+def serialize(obj) -> bytes:
+    return base64.b64encode(pickle.dumps(obj))
 
 
-def load_task(task_id) -> models.Task:
+def serialize_exception(e: Exception) -> bytes:
+    try:
+        return serialize(e)
+    except Exception:
+        return serialize(Exception("Failed to serialize exception: %s" % e))
+
+
+def load_task(task_id: int) -> models.Task:
     return models.Task.objects.get(pk=task_id)
 
 
-def save_task_to_db(new_task, pool_name):
+def save_task_to_db(new_task, pool_name: str) -> models.Task:
     pickled_task = serialize(new_task)
     t = models.Task(pickled_task=pickled_task, pool=pool_name)
     t.save()

--- a/django_leek/server.py
+++ b/django_leek/server.py
@@ -47,13 +47,7 @@ def target(queue):
         except Exception as e:
             log.exception("...task failed")
             task.finished_at = timezone.now()
-            try:
-                task.pickled_exception = helpers.serialize(e)
-            except Exception:
-                log.exception("...failed to serialize exception")
-                task.pickled_exception = helpers.serialize(
-                    Exception("Failed to serialize exception: %s" % e)
-                )
+            task.pickled_exception = helpers.serialize_exception(e)
             task.save()
 
 

--- a/django_leek/server.py
+++ b/django_leek/server.py
@@ -47,7 +47,13 @@ def target(queue):
         except Exception as e:
             log.exception("...task failed")
             task.finished_at = timezone.now()
-            task.pickled_exception = helpers.serialize(e)
+            try:
+                task.pickled_exception = helpers.serialize(e)
+            except Exception:
+                log.exception("...failed to serialize exception")
+                task.pickled_exception = helpers.serialize(
+                    Exception("Failed to serialize exception: %s" % e)
+                )
             task.save()
 
 

--- a/setup.py
+++ b/setup.py
@@ -11,9 +11,9 @@ with open('README.md') as f:
 
 setup(
     name='django-leek',
-    version='1.0.4',
+    version='1.0.5',
     packages=find_packages(exclude=['test_app']),
-    install_requires=['django>=1.11'],
+    install_requires=['django>=3.2'],
     include_package_data=True,
     license='MIT License',
     description='A simple Django app to offload tasks from main web server',
@@ -25,12 +25,12 @@ setup(
     classifiers=[
         'Environment :: Web Environment',
         'Framework :: Django',
-        'Framework :: Django :: 1.11',
+        'Framework :: Django :: 3.2',
         'Intended Audience :: Developers',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.10',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
     ],


### PR DESCRIPTION
Currently see this in the logs when one catalog import task fails:
```
...
urllib.error.HTTPError: HTTP Error 403: Forbidden

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/simon/git/django-leek/django_leek/server.py", line 52, in target
    task.pickled_exception = helpers.serialize(e)
  File "/home/simon/git/django-leek/django_leek/helpers.py", line 13, in serialize
    return base64.b64encode(pickle.dumps(task))
TypeError: cannot pickle '_io.BufferedReader' object
```
And nothing ends up in Sentry, will this change help with that? (will try to test)