### PR TITLE
google cloud structured logging with task context

### DIFF
--- a/django_leek/cloud_logging.py
+++ b/django_leek/cloud_logging.py
@@ -50,21 +50,21 @@ class LoggingContextHandler:
         self.attributes = deque([{}])  # type: deque[dict]
 
     @property
-    def current_attributes(self):
+    def current_attributes(self) -> dict:
         return self.attributes[0]
 
-    def add(self, **new_context_vars):
+    def add(self, **new_context_vars) -> None:
         old_context = self.attributes[0]
         new_context = {**old_context, **new_context_vars}
         self.attributes.appendleft(new_context)
 
-    def get(self, key, default=None):
+    def get(self, key: str, default: Any = None) -> Any:
         return self.attributes[0].get(key, default)
 
-    def remove(self):
+    def remove(self) -> None:
         self.attributes.popleft()
 
-    def __str__(self):
+    def __str__(self) -> str:
         return str(self.attributes)
 
 
@@ -73,7 +73,7 @@ class ImportContextFilter(logging.Filter):
         super(ImportContextFilter, self).__init__()
         self.import_logging_context_handler = import_logging_context_handler
 
-    def filter(self, record):
+    def filter(self, record: logging.LogRecord) -> bool:
         record.tenant_name = self.import_logging_context_handler.get("tenant_name")
 
         namespace_str = ">".join(
@@ -89,7 +89,7 @@ class ImportContextFilter(logging.Filter):
 
 
 class TimestampFilter(logging.Filter):
-    def filter(self, record):
+    def filter(self, record: logging.LogRecord) -> bool:
         record.json_fields = {
             **getattr(record, "json_fields", {}),
             "timestamp": str(timezone.now()),
@@ -98,7 +98,7 @@ class TimestampFilter(logging.Filter):
 
 
 @contextmanager
-def append_logger_context_namespace(logger: logging.Logger, namespace: str):
+def append_logger_context_namespace(logger: logging.Logger, namespace: str) -> None:
     logging_context_handler = LOGGING_CONTEXT_MANAGERS[logger.name]
     try:
         next_attributes = copy.deepcopy(logging_context_handler.current_attributes)
@@ -113,7 +113,7 @@ def append_logger_context_namespace(logger: logging.Logger, namespace: str):
 @contextmanager
 def logger_context(
     logger: logging.Logger, namespace: Union[str, Sequence[str]], **kwargs
-):
+) -> None:
     logging_context_handler = LOGGING_CONTEXT_MANAGERS[logger.name]
     try:
         if isinstance(namespace, str):

--- a/django_leek/cloud_logging.py
+++ b/django_leek/cloud_logging.py
@@ -1,0 +1,161 @@
+import copy
+import logging
+import sys
+from collections import deque
+from contextlib import contextmanager
+from typing import Any, Sequence, Union
+
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+from django.utils import timezone
+from google.cloud.logging_v2.handlers.structured_log import StructuredLogHandler
+
+FORMAT = "%(message)s"
+IMPORT_FORMAT = "[%(namespace)s] tenant:%(tenant_name)s| %(message)s"
+UNSTRUCTURED_FORMAT = "%(asctime)s |%(threadName)-10s| %(filename)31s:%(lineno)-4d |%(levelname)7s| {message_format}"
+
+LOGGING_CONTEXT_MANAGERS = dict()  # type: dict[str, LoggingContextHandler]
+
+
+def get_logger(name: str) -> Any:
+    if name not in LOGGING_CONTEXT_MANAGERS:
+        logging_context_handler = LoggingContextHandler()
+        context_filter = ImportContextFilter(logging_context_handler)
+
+        logger = setup_logging(name=name, format=IMPORT_FORMAT)
+        logger.addFilter(context_filter)
+
+        LOGGING_CONTEXT_MANAGERS[name] = logging_context_handler
+        return logger
+
+    logger = logging.getLogger(name)
+    return logger
+
+
+class LoggingContextHandler:
+    """Allows having a stack of logging context variables.
+    Each time you add to the stack the logger will get new context variables.
+    Each time you remove it will go to the ones it had previously.
+    This allows stacking like:
+    with logger_context(contextvars_1):
+        log.info() -> log with contextvars_1
+
+        with logger_context(contextvars_2):
+            log.info() -> log with contextvars_2
+
+        log.info() -> log with contextvars_1 again
+    """
+
+    def __init__(self):
+        self.attributes = deque([{}])  # type: deque[dict]
+
+    @property
+    def current_attributes(self):
+        return self.attributes[0]
+
+    def add(self, **new_context_vars):
+        old_context = self.attributes[0]
+        new_context = {**old_context, **new_context_vars}
+        self.attributes.appendleft(new_context)
+
+    def get(self, key, default=None):
+        return self.attributes[0].get(key, default)
+
+    def remove(self):
+        self.attributes.popleft()
+
+    def __str__(self):
+        return str(self.attributes)
+
+
+class ImportContextFilter(logging.Filter):
+    def __init__(self, import_logging_context_handler: LoggingContextHandler):
+        super(ImportContextFilter, self).__init__()
+        self.import_logging_context_handler = import_logging_context_handler
+
+    def filter(self, record):
+        record.tenant_name = self.import_logging_context_handler.get("tenant_name")
+
+        namespace_str = ">".join(
+            self.import_logging_context_handler.get("namespace", [])
+        )
+        record.namespace = namespace_str.upper()
+        record.json_fields = {
+            **getattr(record, "json_fields", {}),
+            "tenant_name": record.tenant_name,
+            "namespace": record.namespace,
+        }
+        return True
+
+
+class TimestampFilter(logging.Filter):
+    def filter(self, record):
+        record.json_fields = {
+            **getattr(record, "json_fields", {}),
+            "timestamp": str(timezone.now()),
+        }
+        return True
+
+
+@contextmanager
+def append_logger_context_namespace(logger: logging.Logger, namespace: str):
+    logging_context_handler = LOGGING_CONTEXT_MANAGERS[logger.name]
+    try:
+        next_attributes = copy.deepcopy(logging_context_handler.current_attributes)
+        current_namespace = next_attributes.get("namespace", [])
+        next_attributes["namespace"] = current_namespace + [namespace]
+        logging_context_handler.add(**next_attributes)
+        yield
+    finally:
+        logging_context_handler.remove()
+
+
+@contextmanager
+def logger_context(
+    logger: logging.Logger, namespace: Union[str, Sequence[str]], **kwargs
+):
+    logging_context_handler = LOGGING_CONTEXT_MANAGERS[logger.name]
+    try:
+        if isinstance(namespace, str):
+            # convert namespace to sequence
+            namespace = [namespace]
+        logging_context_handler.add(namespace=namespace, **kwargs)
+        yield
+    finally:
+        logging_context_handler.remove()
+
+
+def _structured_log() -> bool:
+    try:
+        return settings.STRUCTURED_LOG
+    except ImproperlyConfigured:
+        return False
+
+
+def _get_handler(format: str) -> logging.StreamHandler:
+    if _structured_log():
+        log_handler: logging.StreamHandler = StructuredLogHandler(stream=sys.stderr)
+        log_handler.setFormatter(logging.Formatter(FORMAT))
+    else:
+        log_handler = logging.StreamHandler(stream=sys.stderr)
+        log_handler.setFormatter(
+            logging.Formatter(UNSTRUCTURED_FORMAT.format(message_format=format))
+        )
+    return log_handler
+
+
+def setup_logging(name: str, format: str) -> logging.Logger:
+    """Sets up and returns the recommendation logger."""
+    logger = logging.getLogger(name)
+    logger.setLevel(
+        logging.DEBUG
+    )  # logger passes on everything, but the handler may filter
+    logger.handlers = []
+    log_handler = _get_handler(format)
+    log_handler.setLevel(logging.INFO)
+    logger.addHandler(log_handler)
+
+    if _structured_log():
+        logger.addFilter(TimestampFilter())
+
+    return logger

--- a/django_leek/cloud_logging.py
+++ b/django_leek/cloud_logging.py
@@ -128,7 +128,7 @@ def logger_context(
 def _structured_log() -> bool:
     try:
         return settings.STRUCTURED_LOG
-    except ImproperlyConfigured:
+    except (ImproperlyConfigured, AttributeError):
         return False
 
 

--- a/django_leek/server.py
+++ b/django_leek/server.py
@@ -36,9 +36,7 @@ def target(queue):
 
         pickled_task = helpers.unpack(task.pickled_task)
 
-        with logger_context(
-            logger=log, namespace="leek task", pool=task.pool, **pickled_task.kwargs
-        ):
+        with logger_context(logger=log, namespace=task.pool, **pickled_task.kwargs):
             log.info("running task...")
             try:
                 task.started_at = timezone.now()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 django==3.2.14
+google-cloud-logging==3.0.0
 
 # for development
 pylint

--- a/setup.py
+++ b/setup.py
@@ -5,33 +5,33 @@ from setuptools import find_packages, setup
 os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 
-with open('README.md') as f:
+with open("README.md") as f:
     README = f.read()
 
 
 setup(
-    name='django-leek',
-    version='1.0.5',
-    packages=find_packages(exclude=['test_app']),
-    install_requires=['django>=3.2'],
+    name="django-leek",
+    version="1.0.6",
+    packages=find_packages(exclude=["test_app"]),
+    install_requires=["django>=3.2", "google-cloud-logging>=3.0.0"],
     include_package_data=True,
-    license='MIT License',
-    description='A simple Django app to offload tasks from main web server',
+    license="MIT License",
+    description="A simple Django app to offload tasks from main web server",
     long_description=README,
-    long_description_content_type='text/markdown',
-    url='https://github.com/Volumental/django-leek',
-    author='Volumental',
-    author_email='maintainer@volumental.com',
+    long_description_content_type="text/markdown",
+    url="https://github.com/Volumental/django-leek",
+    author="Volumental",
+    author_email="maintainer@volumental.com",
     classifiers=[
-        'Environment :: Web Environment',
-        'Framework :: Django',
-        'Framework :: Django :: 3.2',
-        'Intended Audience :: Developers',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.10',
-        'Topic :: Internet :: WWW/HTTP',
-        'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
+        "Environment :: Web Environment",
+        "Framework :: Django",
+        "Framework :: Django :: 3.2",
+        "Intended Audience :: Developers",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.10",
+        "Topic :: Internet :: WWW/HTTP",
+        "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
     ],
 )


### PR DESCRIPTION
use same logger as fitapi which logs as json with tenant name etc attached to each message

file is copied from here https://github.com/Volumental/fit-api/blob/master/backend/shoes/cloud_logging.py with very minor simplification

looks something like this when running locally
```
2024-09-11 14:44:42,300 |MainThread|                       server.py:83   |   INFO| [] tenant:None| Got a task
2024-09-11 14:44:42,306 |MainThread|                       server.py:97   |   INFO| [] tenant:None| Spawning new pool: _import_catalog
 2024-09-11 14:44:42,315 |ThreadPoolExecutor-0_0|                      catalog.py:60   |   INFO| Import catalog job scheduled: {'task': 'queued', 'task_id': 129821}
{"remote_address": "127.0.0.1", "time": "[11/Sep/2024:14:44:42 +0000]", "method": "PUT", "uri": "/v3/shoes/catalog/import/footjoy/catalog.csv", "status": "202", "bytes_out": "34", "user_agent": "python-requests/2.32.2"}
2024-09-11 14:44:42,319 |MainThread|                       server.py:20   |   INFO| [] tenant:None| Worker Starts
2024-09-11 14:44:42,319 |MainThread|                       server.py:26   |   INFO| [] tenant:None| loading task...
2024-09-11 14:44:42,328 |MainThread|                       server.py:42   |   INFO| [LEEK TASK] tenant:footjoy| running task...
importing catalog
2024-09-11 14:44:42,331 |MainThread|               import_catalog.py:273  |   INFO| [IMPORT CATALOG] tenant:footjoy| Loading catalog from gcloud for tenant footjoy with normalization footjoy
{"remote_address": "127.0.0.1", "time": "[11/Sep/2024:14:44:42 +0000]", "method": "GET", "uri": "/v3/task/129821", "status": "200", "bytes_out": "20", "user_agent": "python-requests/2.32.2"}
/home/simon/git/fit-api/venv/lib/python3.10/site-packages/google/auth/_default.py:76: UserWarning: Your application has authenticated using end user credentials from Google Cloud SDK without a quota project. You might receive a "quota exceeded" or "API not enabled" error. See the following page for troubleshooting: https://cloud.google.com/docs/authentication/adc-troubleshooting/user-creds. 
  warnings.warn(_CLOUD_SDK_CREDENTIALS_WARNING)
2024-09-11 14:44:43,098 |MainThread|                      catalog.py:306  |   INFO| [IMPORT CATALOG] tenant:footjoy| Normalizing catalog
2024-09-11 14:44:43,170 |MainThread|                       server.py:53   |  ERROR| [LEEK TASK] tenant:footjoy| ...task failed
Traceback (most recent call last):
  File "/home/simon/git/django-leek/django_leek/server.py", line 46, in target
    return_value = pickled_task()
  File "/home/simon/git/django-leek/django_leek/api.py", line 32, in __call__
    return self.task_callable(*self.args, **self.kwargs)
  File "/home/simon/git/fit-api/backend/shoes/views/catalog.py", line 74, in _import_catalog
    import_catalog(
  File "/home/simon/git/fit-api/backend/shoes/import_catalog.py", line 278, in import_catalog
    catalog = backend.shoes.data_normalization.catalog.load_catalog(
  File "/home/simon/git/fit-api/backend/shoes/data_normalization/catalog.py", line 307, in load_catalog
    df_catalog = load_normalized_catalog_from_raw(
  File "/home/simon/git/fit-api/backend/shoes/data_normalization/catalog.py", line 232, in load_normalized_catalog_from_raw
    df_catalog = CatalogDF(loader(f))
  File "/home/simon/git/fit-api/backend/shoes/data_normalization/footjoy.py", line 40, in load_catalog_from
    return normalize_catalog(pd.read_csv(catalog, dtype=str, low_memory=False, on_bad_lines="skip"))
  File "/home/simon/git/fit-api/backend/shoes/data_normalization/footjoy.py", line 36, in normalize_catalog
    return default.normalize_catalog(df_catalog)
  File "/home/simon/git/fit-api/backend/shoes/data_normalization/default.py", line 226, in normalize_catalog
    raise NotImplementedError("This function is not implemented yet")
NotImplementedError: This function is not implemented yet
{"remote_address": "127.0.0.1", "time": "[11/Sep/2024:14:44:47 +0000]", "method": "GET", "uri": "/v3/task/129821", "status": "200", "bytes_out": "67", "user_agent": "python-requests/2.32.2"}
```

and gcp:
![image](https://github.com/user-attachments/assets/87d1fa27-4c58-4e03-aebb-5d82a546f18d)
