### PR TITLE
more specific log message for task failed

### DIFF
--- a/django_leek/server.py
+++ b/django_leek/server.py
@@ -48,7 +48,11 @@ def target(queue):
 
                 log.info("...successfully")
             except Exception as e:
-                log.exception("...task failed")
+                log.exception(
+                    "leek task failed: %s %s",
+                    task.pool,
+                    pickled_task.kwargs.get("tenant_name"),
+                )
                 task.finished_at = timezone.now()
                 task.pickled_exception = helpers.serialize_exception(e)
                 task.save()

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open("README.md") as f:
 
 setup(
     name="django-leek",
-    version="1.0.6",
+    version="1.0.7",
     packages=find_packages(exclude=["test_app"]),
     install_requires=["django>=3.2", "google-cloud-logging>=3.0.0"],
     include_package_data=True,


### PR DESCRIPTION
all errors in leek tasks are now grouped under the same issue in sentry (so there is no alert for new errors or regressions)

this suggests to split them by task function/type/pool (import catalog, import inventory, etc) and tenant like:
[leek task failed: _import_catalog ccm_internal](https://volumental.sentry.io/issues/6236630056/?project=1431225&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=30d&stream_index=0)

https://volumental.monday.com/boards/4012902379/pulses/7556767798