### PR TITLE
add updated release requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,11 +149,11 @@ You can run a cron script, or other script, to purge the tasks.
 3. Make sure version in `setup.py` is correct. `grep version setup.py`
 4. Make sure setuptools, twine, and wheel are installed and up to date  
 
-       pip install "setuptools>=38.6.0" "twine>=1.11.0" "wheel>=0.31.0"
+       pip install -r requirements_release.txt
 
 5. Clean out any old dist packages. `rm -r dist/`
 6. Build source and wheel dists. `python setup.py sdist bdist_wheel`
-7. Upload to PyPI `twine upload dist/*`
+7. Upload to PyPI (API token is in 1password) `twine upload dist/*`
 8. Profit!
 
 ## Authors

--- a/requirements_release.txt
+++ b/requirements_release.txt
@@ -1,0 +1,3 @@
+setuptools==70.0.0
+twine==3.6.0
+wheel==0.37.0


### PR DESCRIPTION
I got this email after uploading the 1.0.7 release

> 
> This email is notifying you of an upcoming deprecation that we have determined may affect you as a result of your recent upload to 'django-leek'.
> 
> In the future, PyPI will require all newly uploaded source distribution filenames to comply with [PEP 625](https://peps.python.org/pep-0625/). Any source distributions already uploaded will remain in place as-is and do not need to be updated.
> 
> Specifically, your recent upload of 'django-leek-1.0.7.tar.gz' is incompatible with PEP 625 because it does not contain the normalized project name 'django_leek'.
> 
> In most cases, this can be resolved by upgrading the version of your build tooling to a later version that supports PEP 625 and produces compliant filenames.
> 
> If you have questions, you can email [admin@pypi.org](mailto:admin@pypi.org) to communicate with the PyPI [admin@pypi.org](mailto:admin@pypi.org) to communicate with the PyPI administrators.

verified that the filename is `django_leek-1.0.7.tar.gz` after upgrading